### PR TITLE
Metal modal issue #9

### DIFF
--- a/demos/index.html
+++ b/demos/index.html
@@ -15,10 +15,12 @@
 	<button type="button" class="btn btn-primary openModal">Open Modal</button>
 	<script type="text/javascript">
 		window.modal = new metal.Modal({
-			element: '.modal',
-			header: '<h4 class="modal-title">Modal header</h4>',
 			body: 'One fine body...',
-			footer: '<button type="button" class="btn btn-primary">OK</button>'
+			disableDrag: false,
+			element: '.modal',
+			footer: '<button type="button" class="btn btn-primary">OK</button>',
+			header: '<h4 class="modal-title">Modal header</h4>',
+			offsetTop: 200
 		});
 
 		document.querySelector('.openModal').addEventListener('click', function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-modal",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Metal's modal component",
   "license": "BSD",
   "repository": "metal/metal-modal",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metal-modal",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Metal's modal component",
   "license": "BSD",
   "repository": "metal/metal-modal",

--- a/package.json
+++ b/package.json
@@ -29,11 +29,9 @@
     "modal"
   ],
   "dependencies": {
-    "metal": "^2.0.0",
-    "metal-component": "^2.0.0",
-    "metal-dom": "^2.0.0",
-    "metal-events": "^2.0.0",
-    "metal-soy": "^2.0.0"
+    "metal-component": "^1.0.0-rc.11",
+    "metal-drag-drop": "^2.0.1",
+    "metal-soy": "^1.0.0-rc.11"
   },
   "devDependencies": {
     "bootstrap": "^3.3.6",

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -278,8 +278,8 @@ Modal.STATE = {
 	 * @type {Element}
 	 */
 	overlayElement: {
-		initOnly: true,
-		valueFn: 'valueOverlayElementFn_'
+		valueFn: 'valueOverlayElementFn_',
+		writeOnce: true
 	},
 
 	/**

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -23,6 +23,8 @@ class Modal extends Component {
 	 */
 	attached() {
 		this.autoFocus_(this.autoFocus);
+
+		this.addListener('hide', this.defaultHideFn_, true);
 	}
 
 	/**
@@ -38,6 +40,13 @@ class Modal extends Component {
 				element.focus();
 			}
 		}
+	}
+
+	/**
+	 * Run only if no listener calls event.preventDefault().
+	 */
+	defaultHideFn_() {
+		this.visible = false;
 	}
 
 	/**
@@ -81,10 +90,10 @@ class Modal extends Component {
 	}
 
 	/**
-	 * Hides the modal, setting its `visible` state key to false.
+	 * Emits a hide event.
 	 */
 	hide() {
-		this.visible = false;
+		this.emit('hide');
 	}
 
 	/**

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -212,6 +212,14 @@ Modal.STATE = {
 	},
 
 	/**
+	 * Classes that will be applied to the modal-dialog element.
+	 * @type {string}
+	 */
+	dialogClasses: {
+		validator: core.isString
+	},
+
+	/**
 	 * Content to be placed inside modal footer. Can be either an html string or
 	 * a function that calls incremental-dom to render the footer.
 	 * @type {string|function()}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -7,6 +7,8 @@ import templates from './Modal.soy.js';
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 
+const KEY_CODE_ESC = 27;
+
 /**
  * Modal component.
  */
@@ -84,7 +86,7 @@ class Modal extends Component {
 	 * @protected
 	 */
 	handleKeyup_(event) {
-		if (event.keyCode === 27) {
+		if (event.keyCode === KEY_CODE_ESC) {
 			this.hide();
 		}
 	}

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -186,7 +186,7 @@ Modal.STATE = {
 
 	/**
 	 * Content to be placed inside modal body. Can be either an html string or
-	 * a function that calls incremental dom for rendeirng the body.
+	 * a function that calls incremental-dom to render the body.
 	 * @type {string|function()}
 	 */
 	body: {
@@ -202,7 +202,7 @@ Modal.STATE = {
 
 	/**
 	 * Content to be placed inside modal footer. Can be either an html string or
-	 * a function that calls incremental dom for rendeirng the footer.
+	 * a function that calls incremental-dom to render the footer.
 	 * @type {string|function()}
 	 */
 	footer: {
@@ -218,7 +218,7 @@ Modal.STATE = {
 
 	/**
 	 * Content to be placed inside modal header. Can be either an html string or
-	 * a function that calls incremental dom for rendeirng the header.
+	 * a function that calls incremental-dom to render the header.
 	 * @type {string|function()}
 	 */
 	header: {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,6 +2,7 @@
 
 import core from 'metal';
 import dom from 'metal-dom';
+import { Drag } from 'metal-drag-drop';
 import { EventHandler } from 'metal-events';
 import templates from './Modal.soy.js';
 import Component from 'metal-component';
@@ -18,6 +19,13 @@ class Modal extends Component {
 	 */
 	created() {
 		this.eventHandler_ = new EventHandler();
+
+		this.drag_ = new Drag({
+			disabled: this.get('disableDrag'),
+			handles: '.modal-header',
+			sources: '.modal',
+			useShim: false
+		});
 	}
 
 	/**
@@ -220,6 +228,15 @@ Modal.STATE = {
 	},
 
 	/**
+	 * Boolean to determine whether modal will be draggable.
+	 * @type {Boolean}
+	 */
+	disableDrag: {
+		validator: core.isBoolean,
+		value: false
+	},
+
+	/**
 	 * Content to be placed inside modal footer. Can be either an html string or
 	 * a function that calls incremental-dom to render the footer.
 	 * @type {string|function()}
@@ -261,6 +278,13 @@ Modal.STATE = {
 	 */
 	noCloseButton: {
 		value: false
+	},
+
+	/**
+	 * Number indicating the vertical position of modal in pixels.
+	 * @type {number}
+	 */
+	offsetTop: {
 	},
 
 	/**

--- a/src/Modal.soy
+++ b/src/Modal.soy
@@ -6,6 +6,7 @@
 {template .render}
 	{@param? body: html|string}
 	{@param? bodyId: string}
+	{@param? dialogClasses: string}
 	{@param? elementClasses: string}
 	{@param? footer: html|string}
 	{@param? header: html|string}
@@ -17,7 +18,7 @@
 		class="modal{$elementClasses ? ' ' + $elementClasses : ''}"
 		style="display: {$visible ? 'block' : 'none'}">
 		<div
-			class="modal-dialog"
+			class="modal-dialog{$dialogClasses ? ' ' + $dialogClasses : ''}"
 			tabindex="0"
 			role="{$role ? $role : 'dialog'}"
 			aria-labelledby="{$headerId}"

--- a/src/Modal.soy
+++ b/src/Modal.soy
@@ -12,22 +12,23 @@
 	{@param? header: html|string}
 	{@param? headerId: string}
 	{@param? noCloseButton: bool}
+	{@param? offsetTop: number}
 	{@param? role: string}
 	{@param? visible: bool}
 	<div
 		class="modal{$elementClasses ? ' ' + $elementClasses : ''}"
 		style="display: {$visible ? 'block' : 'none'}">
 		<div
-			class="modal-dialog{$dialogClasses ? ' ' + $dialogClasses : ''}"
-			tabindex="0"
-			role="{$role ? $role : 'dialog'}"
+			aria-describedby="{$bodyId}"
 			aria-labelledby="{$headerId}"
-			aria-describedby="{$bodyId}">
-			<div class="modal-content">
+			class="modal-dialog{$dialogClasses ? ' ' + $dialogClasses : ''}"
+			role="{$role ? $role : 'dialog'}"
+			tabindex="0">
+			<div class="modal-content" style="top: {$offsetTop}px">
 				<header class="modal-header">
 					{if $header}
 						{if not $noCloseButton}
-							<button type="button" class="close" data-onclick="hide" aria-label="Close">
+							<button aria-label="Close" class="close" data-onclick="hide" type="button">
 								<span aria-hidden="true">×</span>
 							</button>
 						{/if}

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,7 +1,8 @@
 {
   "mocha": true,
   "globals": {
-    "assert": true
+    "assert": true,
+    "sinon": true
   },
   "extends": "../.jshintrc"
 }

--- a/test/Modal.js
+++ b/test/Modal.js
@@ -380,15 +380,16 @@ describe('Modal', function() {
 		});
 	});
 
-	it('should modal progressive enchance always as hidden', function() {
+	it('should progressive enhance always as hidden', function() {
 		var data = {
-			id: 'modal',
-			elementClasses: 'centered',
-			header: 'header',
-			headerId: 'header',
 			body: 'body',
 			bodyId: 'header',
+			elementClasses: 'centered',
 			footer: 'footer',
+			header: 'header',
+			headerId: 'header',
+			id: 'modal',
+			noCloseButton: true,
 			overlay: true,
 			role: 'dialog'
 		};
@@ -397,13 +398,14 @@ describe('Modal', function() {
 		var outerHTML = element.innerHTML;
 
 		modal = new Modal({
-			element: element.childNodes[0],
-			elementClasses: 'centered',
-			header: 'header',
-			headerId: 'header',
 			body: 'body',
 			bodyId: 'header',
+			element: element.childNodes[0],
+			elementClasses: 'centered',
 			footer: 'footer',
+			header: 'header',
+			headerId: 'header',
+			noCloseButton: true,
 			visible: false
 		});
 

--- a/test/Modal.js
+++ b/test/Modal.js
@@ -483,4 +483,12 @@ describe('Modal', function() {
 		modal.hide();
 		assert.ok(modal.visible);
 	});
+
+	it('should add classes passed to "dialogClasses" to the modal dialog element', function() {
+		modal = new Modal({
+			dialogClasses: 'modal-lg'
+		});
+		var dialog = modal.element.querySelector('.modal-dialog');
+		assert.ok(dialog.classList.contains('modal-lg'));
+	});
 });

--- a/test/Modal.js
+++ b/test/Modal.js
@@ -462,4 +462,25 @@ describe('Modal', function() {
 		modal.show();
 		assert.ok(modal.visible);
 	});
+
+	it('should emit the "hide" event when the hide method is called', function() {
+		var spy = sinon.spy();
+		modal = new Modal({
+			events: {hide: spy},
+			visible: false
+		});
+		modal.hide();
+		assert.ok(spy.called);
+	});
+
+	it('should not set visibility to false on "hide" when preventDefault is called on the hide event', function() {
+		modal = new Modal({
+			events: {
+				hide: event => event.preventDefault()
+			},
+			visible: true
+		});
+		modal.hide();
+		assert.ok(modal.visible);
+	});
 });


### PR DESCRIPTION
Using metal dependencies with version ^2.0.0 throws errors in the Chrome console. The demos don't work and I get the error 'Metal.modal is not a constructor'. Changing the version of the dependencies to ^1.0.0 fixes the issue for now.   